### PR TITLE
Fixe files import

### DIFF
--- a/Classes/Processors/ProductAttributeProcessor.php
+++ b/Classes/Processors/ProductAttributeProcessor.php
@@ -161,7 +161,7 @@ class ProductAttributeProcessor extends AbstractFieldProcessor
             case Attribute::ATTRIBUTE_TYPE_IMAGE:
             case Attribute::ATTRIBUTE_TYPE_FILE:
                 $this->updateAttributeFilesReference($value);
-                $attributeValues[$this->attribute->getUid()] = (string)$value;
+                $attributeValues[$this->attribute->getUid()] = is_array($value) ? implode(',', $value) : (string)$value;
                 break;
             default:
                 // @codingStandardsIgnoreStart
@@ -303,10 +303,11 @@ class ProductAttributeProcessor extends AbstractFieldProcessor
     /**
      * Update attribute file reference
      *
-     * @param string $value
+     * @param string|array $value Array of file list or comma separated list
      */
-    protected function updateAttributeFilesReference(string $value): void
+    protected function updateAttributeFilesReference($value): void
     {
+        $value = $this->convertFilesListValueToArray($value);
         try {
             $folder = $this->getFolder();
         } catch (FolderDoesNotExistException $exception) {

--- a/Classes/Processors/Relation/AbstractRelationFieldProcessor.php
+++ b/Classes/Processors/Relation/AbstractRelationFieldProcessor.php
@@ -36,9 +36,6 @@ abstract class AbstractRelationFieldProcessor extends AbstractFieldProcessor
      */
     public function preProcess(&$value): void
     {
-        if (!is_string($value)) {
-            $value = (string)$value;
-        }
         parent::preProcess($value);
 
         $this->entities = $this->initEntities($value);

--- a/Classes/Processors/Relation/Files/LocalFileProcessor.php
+++ b/Classes/Processors/Relation/Files/LocalFileProcessor.php
@@ -28,6 +28,7 @@ class LocalFileProcessor extends AbstractRelationFieldProcessor
     protected function initEntities($value): array
     {
         $entities = [];
+        $value = $this->convertFilesListValueToArray($value);
 
         try {
             $folder = $this->getFolder();

--- a/Classes/Processors/Traits/FilesResources.php
+++ b/Classes/Processors/Traits/FilesResources.php
@@ -100,18 +100,18 @@ trait FilesResources
      * Get array of Files from path list
      *
      * @param Folder $folder
-     * @param string $list
+     * @param array $list
      * @param Logger|null $logger
      * @return File[]
      */
-    protected function collectFilesFromList(Folder $folder, string $list, Logger $logger = null): array
+    protected function collectFilesFromList(Folder $folder, array $list, Logger $logger = null): array
     {
         $storage = $this->getStorage();
 
         /** @var File[] $files */
         $files = [];
 
-        foreach (GeneralUtility::trimExplode(',', $list, true) as $filePath) {
+        foreach ($list as $filePath) {
             $fileIdentifier = $folder->getIdentifier() . ltrim($filePath, '/');
 
             // Emit signal
@@ -128,5 +128,27 @@ trait FilesResources
         }
 
         return $files;
+    }
+
+    /**
+     * Convert to array if list is string.
+     *
+     * @param array|string $list Only array or string comma separated list is allowed as files list
+     * @return array
+     */
+    protected function convertFilesListValueToArray($list): array
+    {
+        if (!is_array($list) && !is_string($list)) {
+            $type = gettype($list);
+            throw new \InvalidArgumentException(
+                "Expect to get array or string as files list. '{$type}' given.",
+                1560319588819
+            );
+        }
+        if (is_string($list)) {
+            $list = GeneralUtility::trimExplode(',', $list, true);
+        }
+
+        return $list;
     }
 }

--- a/Classes/Processors/Traits/UpdateRelationProperty.php
+++ b/Classes/Processors/Traits/UpdateRelationProperty.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Pixelant\PxaPmImporter\Processors\Traits;
 
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use TYPO3\CMS\Extbase\Persistence\Generic\LazyLoadingProxy;
@@ -123,10 +125,35 @@ trait UpdateRelationProperty
             }
             // If relation 1:1
             if ($propertyValue instanceof AbstractEntity
-                && $firstEntity !== null
-                && $this->getEntityUidForCompare($firstEntity) !== $propertyValue->getUid()
+                && (
+                    $firstEntity === null
+                    || $this->getEntityUidForCompare($firstEntity) !== $propertyValue->getUid()
+                )
             ) {
-                ObjectAccess::setProperty($entity, $property, $firstEntity);
+                // If new value is null and current is file reference need to delete it also
+                if ($firstEntity === null && $propertyValue instanceof FileReference) {
+                    // @TODO $propertyValue->getOriginalResource()->delete(); doesn't work. How to properly delete file reference?
+                    // Just setting null not enough for 1:1 relation with file reference.
+                    // Extbase only set null on field of entity table and doesn't update sys_file_reference table
+                    // Which is odd, because work with Object storage
+                    $uid = $propertyValue->_getProperty('_languageUid') > 0
+                        ? $propertyValue->_getProperty('_localizedUid')
+                        : $propertyValue->getUid();
+                    $deleteColumn = $GLOBALS['TCA']['sys_file_reference']['ctrl']['delete'];
+
+                    // Do direct query
+                    GeneralUtility::makeInstance(ConnectionPool::class)
+                        ->getConnectionForTable('sys_file_reference')
+                        ->update(
+                            'sys_file_reference',
+                            [$deleteColumn => 1],
+                            ['uid' => $uid],
+                            [\PDO::PARAM_INT]
+                        );
+                }
+                // If entity is null we need to use direct access, because it's high risk that
+                // setter method except only objects, but we need to reset value
+                ObjectAccess::setProperty($entity, $property, $firstEntity, $firstEntity === null);
             }
         } elseif ($firstEntity !== null) {
             ObjectAccess::setProperty($entity, $property, $firstEntity);

--- a/Tests/Build/FunctionalTests.xml
+++ b/Tests/Build/FunctionalTests.xml
@@ -10,7 +10,6 @@
          stopOnFailure="false"
          stopOnIncomplete="false"
          stopOnSkipped="false"
-         strict="false"
          verbose="false">
     <testsuites>
         <testsuite name="EXT:pxa_pm_importer tests">

--- a/Tests/Build/UnitTests.xml
+++ b/Tests/Build/UnitTests.xml
@@ -10,7 +10,6 @@
          stopOnFailure="false"
          stopOnIncomplete="false"
          stopOnSkipped="false"
-         strict="false"
          verbose="false"
          cacheTokens="true">
     <testsuites>

--- a/Tests/Unit/Processors/Traits/FilesResourcesTest.php
+++ b/Tests/Unit/Processors/Traits/FilesResourcesTest.php
@@ -134,4 +134,37 @@ class FilesResourcesTest extends UnitTestCase
         ];
         $this->getFolder();
     }
+
+    /**
+     * @test
+     */
+    public function convertFilesListValueToArrayThrowExceptionIfNonArrayOrNonStringGiven()
+    {
+        $list = 123;
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->convertFilesListValueToArray($list);
+    }
+
+    /**
+     * @test
+     */
+    public function convertFilesListValueToArrayReturnGivenArray()
+    {
+        $list = ['path1', 'path2'];
+
+        $this->assertEquals($list, $this->convertFilesListValueToArray($list));
+    }
+
+    /**
+     * @test
+     */
+    public function convertFilesListValueToArrayConvertStringToArray()
+    {
+        $list = 'path1,path2, path3';
+        $expect = ['path1', 'path2', 'path3'];
+
+        $this->assertEquals($expect, $this->convertFilesListValueToArray($list));
+    }
 }


### PR DESCRIPTION
1. Make it possible to reset(set null) property value with relation 1:1. For example, this will remove parent from category if parent was removed in import source.
2. Files processor now accept also array as files list.