### PR TITLE
[TASK] use dash when generate import file name, because TYPO3 usecolo…

### DIFF
--- a/Classes/Logging/Writer/FileWriter.php
+++ b/Classes/Logging/Writer/FileWriter.php
@@ -89,6 +89,6 @@ class FileWriter extends LogFileWriter
      */
     protected function getLogFileDate(): string
     {
-        return date('Y-m-d_H:i:s');
+        return date('Y-m-d_H-i-s');
     }
 }


### PR DESCRIPTION
…n to explode and find storage ID